### PR TITLE
add seed file and seed development database

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
       activemodel (= 5.1.4)
       activesupport (= 5.1.4)
       arel (~> 8.0)
+    activerecord-reset-pk-sequence (0.2.1)
     activesupport (5.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -96,6 +97,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
+  activerecord-reset-pk-sequence
   capybara
   database_cleaner
   launchy

--- a/app/views/stations/show.erb
+++ b/app/views/stations/show.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Station Page</title>
+    <title>Station Page <%= @station.name %></title>
   </head>
   <body>
     <%= @station.name %><br>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,20 @@
+require 'csv'
+require 'pry'
+require './app/models/station'
+
+class Seed
+
+  def self.station
+    options = {headers: true, header_converters: :symbol, converters: :numeric}
+    CSV.foreach('./db/csv/station.csv', options) do |row|
+      Station.create(installation_date: Date.strptime(row[:installation_date], "%m/%d/%Y"),
+      name: row[:name],
+      city: row[:city],
+      dock_count: row[:dock_count])
+    end
+  end
+
+end
+
+Station.destroy_all
+Seed.station


### PR DESCRIPTION
Added destroy_all method so it will remove any data in the database if we re-seed. Also found that db drop, create, migrate, and then seed works best in order to ensure the id's start at 1 when we re-seed.

Please review.